### PR TITLE
Meeting Style Preference & Respondent supplied topics of interest

### DIFF
--- a/pages/topic_interest.Rmd
+++ b/pages/topic_interest.Rmd
@@ -5,6 +5,8 @@ output: html_document
 
 ```{r echo=FALSE, message=FALSE, warning=FALSE}
 library(tidyverse)
+library(magrittr)
+library(kableExtra)
 ```
 
 
@@ -32,6 +34,43 @@ df %>% select(InterestCustomAITool, CombinedInterestAIPolicy, CombinedInterestEt
 ```
 
 # Respondent provided suggestions
+
+```{r echo=FALSE, message=FALSE, warning=FALSE, fig.width = , fig.height = }
+userSpecifiedTOI <- df %>% select(TopicsOfInterest) %>%
+    mutate(TopicsOfInterest = recode(TopicsOfInterest, "Not sure" = NA_character_)) %>% #change Not sure to NA
+    filter(!str_detect(TopicsOfInterest, "but")) %>% #remove not suggestions
+    drop_na() %>% #drop the NA I introduced
+    separate_longer_delim(TopicsOfInterest, delim = "; ") 
+
+expanded <- rbind(
+                  userSpecifiedTOI %>%
+                    filter(!str_detect(TopicsOfInterest, ", ")), #already expanded because of separate_longer_delim with semicolon
+                  userSpecifiedTOI %>%
+                    filter(str_detect(TopicsOfInterest, ", ")) %>% 
+                    mutate(TopicsOfInterest = str_replace_all(TopicsOfInterest, "e.g.", "eg"), #remove extra periods so I can split on period
+                           TopicsOfInterest = str_replace_all(TopicsOfInterest, "eggement", "engagement")) %>% #fix spelling
+                    separate_longer_delim(TopicsOfInterest, delim=". ") %>% #split on end of thought
+                    separate_longer_delim(TopicsOfInterest, delim="?)") %>% #split on end of thought
+                    mutate_at(.vars = "TopicsOfInterest", .funs = trimws) %>% #remove white space delimiters 
+                    separate_longer_delim(TopicsOfInterest, delim=", ") %>% #split on commas within lists
+                    mutate(TopicsOfInterest = 
+                             recode(TopicsOfInterest, "Additionally" = NA_character_, #remove adverb
+                                                      "especially as these tools become more prevalent" = NA_character_, #remove extraneous description
+                                                      "I would also be interested in any discussions of AI-adjacent topics such as the ones mentioned below in the \"Would you be interested...\" question" = NA_character_)) %>% #not really a suggested/novel topic since already asked in survey
+                    drop_na() %>% #drop the NAs I introduced
+                    mutate(TopicsOfInterest = 
+                             recode(TopicsOfInterest, "git tools and patterns for branching/committing releases." = "Open Source software development strategies - git tools and patterns for branching/committing releases.", #add the original descriptor back
+                                                      "One idea is for another presentation on mentoring specifically undegaduates/trainees (I believe there might have been one in the past"= "mentoring specifically undergraduates/trainees", #simplify
+                                                      "or about how scientific education in the computational science sphere might evolve with the increase in generative AI tools (eg how they may hinder or enhance training)" = "how the increase in generative AI tools may hinder or enhance computational science training", #simplify
+                                                      "I think presentations on new \"trends\" in computational tools outside of AI might be useful: for instance" = "new trends in computational tools outside of AI", #simplify
+                                                      "a presentation dedicated to Jupyter Notebook-based resources" = "Jupyter Notebook-based resources", #simplify
+                                                      "or a presentation on how new technologies can improve existing tools (eg how Rust can be used to speed up tools likegeapy)" = "how new technologies can improve existing tools (eg how Rust can be used to speed up tools like gseapy)", #simplify
+                                                      "or current \"hot topics\" (eg knowleg graphs" = "knowledge graphs", #simplify
+                                                      "computer vision)" = "computer vision"))
+                  )
+
+kableExtra::kable(expanded, table.attr = "style='width:20%;'")
+```
 
 # Preferred Meeting Styles
 

--- a/pages/topic_interest.Rmd
+++ b/pages/topic_interest.Rmd
@@ -33,12 +33,6 @@ df %>% select(InterestCustomAITool, CombinedInterestAIPolicy, CombinedInterestEt
 
 # Respondent provided suggestions
 
-```{r eval=FALSE, echo=FALSE, message=FALSE, warning=FALSE, fig.height = , fig.width = }
-
-
-
-```
-
 # Preferred Meeting Styles
 
 Note: Each respondent could select multiple meeting styles

--- a/pages/topic_interest.Rmd
+++ b/pages/topic_interest.Rmd
@@ -30,3 +30,56 @@ df %>% select(InterestCustomAITool, CombinedInterestAIPolicy, CombinedInterestEt
     theme(legend.position = "none", text = element_text(size = 20)) +
     ggtitle("Would you be interested in\na talk/discussion about...")
 ```
+
+# User provided suggestions
+
+```{r eval=FALSE, echo=FALSE, message=FALSE, warning=FALSE, fig.height = , fig.width = }
+
+
+
+```
+
+# Preferred Meeting Styles
+
+Note: Each respondent could select multiple meeting styles
+
+```{r echo=FALSE, message=FALSE, warning=FALSE, fig.width = 14.98, fig.height = 7.38}
+mycolors <- c(
+  "Discussion" = "#F8766D",
+  "Guest Education Session" = "#B79F00",
+  "ITN Education Session" = "#00BA38",
+  "Research Activity" = "#00BFC4",
+  "Research Talk" = "#619CFF",
+  "Software Introduction" = "#F564E3"
+)
+
+df %>%
+    select(Timestamp, StylePref) %>%
+    separate_longer_delim(StylePref, delim = ", ") %>%
+    mutate(n_responses = length(unique(Timestamp))) %>%
+    group_by(StylePref, n_responses) %>%
+    summarize(n = n()) %>%
+    mutate(percentage = n/n_responses*100) %>%
+    arrange(-n) %>%
+    select(StylePref, percentage) %>%
+    mutate(MeetingAnnot = case_when(StylePref == "Guest speaker talks about a course or training resource" ~ "Guest Education Session",
+       StylePref == "Guest speaker about a topic" ~ "Guest Education Session",
+       StylePref == "Multiple guest speakers about a topic" ~ "Guest Education Session",
+                                    StylePref == "Discussions about a topic" ~ "Discussion",
+                                    StylePref == "Co-working on a project like a manuscript" ~ "Research Activity",
+                                    StylePref == "Guest speaker about their research" ~ "Research Talk",
+                                    StylePref == "A new style where we get CliffNote presentations on books of interest" ~ "ITN Education Session",
+                                    StylePref == "A recorded forum for a podcast episode where cancer informatics topics are discussed" ~ "Discussion"),
+       MeetingAnnot = factor(MeetingAnnot, levels = c("Discussion", "Guest Education Session", "ITN Education Session", "Research Activity", "Research Talk", "Software Introduction")),
+       StylePref = recode(StylePref, "A new style where we get CliffNote presentations on books of interest" = "A new style: CliffNote presentations\non books of interest", "A recorded forum for a podcast episode where cancer informatics topics are discussed" = "A recorded forum for a podcast episode\nwhere cancer informatics topics are discussed", "Guest speaker talks about a course or training resource" = "Guest speaker talks about\na course or training resource")) %>%
+    ggplot(aes(x = percentage, y = reorder(StylePref, percentage), fill=MeetingAnnot)) +
+    geom_bar(stat="identity") +
+    xlim(0,100) +
+    xlab("Percentage of responses") +
+    ylab("") +
+    theme_bw() +
+    theme(text = element_text(size = 20)) +
+    scale_fill_manual(values=mycolors)+
+    labs(fill=NULL) +
+    ggtitle("What style of meeting do you prefer?")
+```

--- a/pages/topic_interest.Rmd
+++ b/pages/topic_interest.Rmd
@@ -31,7 +31,7 @@ df %>% select(InterestCustomAITool, CombinedInterestAIPolicy, CombinedInterestEt
     ggtitle("Would you be interested in\na talk/discussion about...")
 ```
 
-# User provided suggestions
+# Respondent provided suggestions
 
 ```{r eval=FALSE, echo=FALSE, message=FALSE, warning=FALSE, fig.height = , fig.width = }
 

--- a/pages/topic_interest.Rmd
+++ b/pages/topic_interest.Rmd
@@ -35,7 +35,7 @@ df %>% select(InterestCustomAITool, CombinedInterestAIPolicy, CombinedInterestEt
 
 # Respondent provided suggestions
 
-```{r echo=FALSE, message=FALSE, warning=FALSE, fig.width = , fig.height = }
+```{r echo=FALSE, message=FALSE, warning=FALSE}
 userSpecifiedTOI <- df %>% select(TopicsOfInterest) %>%
     mutate(TopicsOfInterest = recode(TopicsOfInterest, "Not sure" = NA_character_)) %>% #change Not sure to NA
     filter(!str_detect(TopicsOfInterest, "but")) %>% #remove not suggestions


### PR DESCRIPTION
Add a graph showing the percent of respondents who selected each meeting style. 

I'm adding this graph to the topic interest page since I feel like topic and meeting style are related. I could also see adding this graph to a new page where the general suggestions question is going to go.

Note that the fill colors are manually set to match the annotation fill colors for the boxplot with the meeting usefulness graph. 